### PR TITLE
.gitignore added *.bak (sln file changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ StyleCopReport.xml
 *.pidb
 *.svclog
 *.scc
+*.bak
 
 # Chutzpah Test files
 _Chutzpah*

--- a/Source/ExportPlaylist/Program.cs
+++ b/Source/ExportPlaylist/Program.cs
@@ -58,7 +58,11 @@ namespace ExportHearts
                 doc = await plex.GetDocumentAsync($"/playlists/{playlistId}/items");
 
                 using FileStream file = File.OpenWrite(options.FilePath);
-                using Utf8JsonWriter writer = new(file);
+                var writerOptions = new JsonWriterOptions
+                {
+                    Indented = true
+                };
+                using Utf8JsonWriter writer = new(file, options: writerOptions);
                 doc.WriteTo(writer);
 
                 Console.WriteLine($"Wrote playlist {title} to {options.FilePath}");

--- a/Source/PlexTools.sln
+++ b/Source/PlexTools.sln
@@ -5,11 +5,11 @@ VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlexNet", "PlexNet\PlexNet.csproj", "{2D3FA496-1C55-4864-8ED5-1417E4B2BD75}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlaylistToRatings", "PlaylistToHearts\PlaylistToRatings.csproj", "{42F0E467-0721-49E3-9BEC-2565B80F3209}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlaylistToRatings", "PlaylistToRatings\PlaylistToRatings.csproj", "{42F0E467-0721-49E3-9BEC-2565B80F3209}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExportPlaylist", "ExportHearts\ExportPlaylist.csproj", "{3545D8CB-53B9-4F43-8233-D503088B6EC1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExportPlaylist", "ExportPlaylist\ExportPlaylist.csproj", "{3545D8CB-53B9-4F43-8233-D503088B6EC1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImportPlaylist", "ImportHearts\ImportPlaylist.csproj", "{F722939E-C602-4F35-B365-62467A9CE33B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImportPlaylist", "ImportPlaylist\ImportPlaylist.csproj", "{F722939E-C602-4F35-B365-62467A9CE33B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WMPToPlex", "WmpToPlex\WMPToPlex.csproj", "{8582CE66-C7D9-4C52-8F33-41B55E444F45}"
 EndProject


### PR DESCRIPTION
.PlexTools.sln corrected path to reflect solution
ExportPlaylist changed to indented export, since more easy to read
.gitignored updated to skip *.bak files (sln file changes)